### PR TITLE
feat: add `anchorLinkPrefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Allows you to customize the anchor link symbol class name. If not null, symbol w
 
 Allows you to prepend/append the anchor link in the headings
 
+#### `anchorLinkPrefix`
+
+(default: `undefined`)
+
+Allows you to add a prefix to the generated header ids, e.g. `section-`.
+
 #### `anchorClassName`
 
 (default: `"markdownIt-Anchor"`)

--- a/src/__tests__/anchor.js
+++ b/src/__tests__/anchor.js
@@ -58,4 +58,20 @@ test("markdown-it-toc-and-anchor anchor", (t) => {
     `<span class="octicon octicon-link"></span></a>Heading</h1>\n`,
     "should support GitHub style anchor link"
   )
+
+  t.is(
+    mdIt(
+      `
+# Hello World
+`,
+      {
+        anchorLink: true,
+        anchorLinkPrefix: "section-",
+      }
+    ),
+/* eslint-disable max-len */
+  `<h1 id="section-hello-world"><a class="markdownIt-Anchor" href="#section-hello-world">#</a> Hello World</h1>\n`,
+/* eslint-enable max-len */
+    "should use prefix"
+  )
 })

--- a/src/index.js
+++ b/src/index.js
@@ -183,6 +183,10 @@ export default function(md, options) {
               .reduce((acc, t) => acc + t.content, ""), headingIds)
         }
 
+        if (options.anchorLinkPrefix) {
+          heading._tocAnchor = options.anchorLinkPrefix + heading._tocAnchor
+        }
+
         tocArray.push({
           content,
           anchor: heading._tocAnchor,


### PR DESCRIPTION
Allows you to add a prefix to the generated header ids, e.g. `section-`.

``` javascript
markdownIt().use(markdownItTocAndAnchor, {
  anchorLinkPrefix: 'section-'
}).render('# hello world')

//  <h1 id="section-hello-world">
//    <a class="markdownIt-Anchor" href="#section-hello-world">#</a>
//     hello world
//  </h1>'
```
