### PR TITLE
feat: added a wrapHeadingTextInAnchor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Allows you to prepend/append the anchor link in the headings
 
 Allows you to customize the anchor link class
 
+#### `wrapHeadingTextInAnchor`
+
+(default: `false`)
+
+Makes the entire heading into the anchor link (takes precedence over `anchorLinkSymbol` and `anchorLinkBefore`)
+
 #### `resetIds`
 
 (default: `true`)

--- a/src/__tests__/anchor.js
+++ b/src/__tests__/anchor.js
@@ -58,4 +58,20 @@ test("markdown-it-toc-and-anchor anchor", (t) => {
     `<span class="octicon octicon-link"></span></a>Heading</h1>\n`,
     "should support GitHub style anchor link"
   )
+
+  t.is(
+    mdIt(
+      `@[toc]
+# Heading`,
+      {
+        anchorLink: true,
+        wrapHeadingTextInAnchor: true,
+      }
+    ),
+/* eslint-disable max-len */
+  `<p></p>
+<h1 id="heading"><a class="markdownIt-Anchor" href="#heading">Heading</a></h1>\n`,
+/* eslint-enable max-len */
+    "should support wrapping heading text in the anchor link"
+  )
 })

--- a/src/index.js
+++ b/src/index.js
@@ -53,32 +53,41 @@ const renderAnchorLinkSymbol = (options) => {
 }
 
 const renderAnchorLink = (anchor, options, tokens, idx) => {
-  const linkTokens = [
-    {
-      ...(new Token("link_open", "a", 1)),
-      attrs: [
+  const openLinkToken = {
+    ...(new Token("link_open", "a", 1)),
+    attrs: [
         [ "class", options.anchorClassName ],
         [ "href", `#${anchor}` ],
-      ],
-    },
-    ...(renderAnchorLinkSymbol(options)),
-    new Token("link_close", "a", -1),
-  ]
-
-  // `push` or `unshift` according to anchorLinkBefore option
-  // space is at the opposite side.
-  const actionOnArray = {
-    false: "push",
-    true: "unshift",
+    ],
   }
+  const closeLinkToken = new Token("link_close", "a", -1)
 
-  // insert space between anchor link and heading ?
-  if (options.anchorLinkSpace) {
-    linkTokens[actionOnArray[!options.anchorLinkBefore]](space())
+  if (options.wrapHeadingTextInAnchor) {
+    tokens[idx + 1].children.unshift(openLinkToken)
+    tokens[idx + 1].children.push(closeLinkToken)
   }
-  tokens[idx + 1].children[
-    actionOnArray[options.anchorLinkBefore]
-  ](...linkTokens)
+  else {
+    const linkTokens = [
+      openLinkToken,
+      ...(renderAnchorLinkSymbol(options)),
+      closeLinkToken,
+    ]
+
+    // `push` or `unshift` according to anchorLinkBefore option
+    // space is at the opposite side.
+    const actionOnArray = {
+      false: "push",
+      true: "unshift",
+    }
+
+    // insert space between anchor link and heading ?
+    if (options.anchorLinkSpace) {
+      linkTokens[actionOnArray[!options.anchorLinkBefore]](space())
+    }
+    tokens[idx + 1].children[
+      actionOnArray[options.anchorLinkBefore]
+    ](...linkTokens)
+  }
 }
 
 const treeToMarkdownBulletList = (tree, indent = 0) => tree.map(item => {
@@ -140,6 +149,7 @@ export default function(md, options) {
     resetIds: true,
     anchorLinkSpace: true,
     anchorLinkSymbolClassName: null,
+    wrapHeadingTextInAnchor: false,
     ...options,
   }
 


### PR DESCRIPTION
When true, it bypasses anchorLinkSymbol and instead wraps the anchor link around the heading text:

``` js
require('markdown-it')()
  .use(require('markdown-it-toc-and-anchor'), { wrapHeadingTextInAnchor: true })
  .render(`# Heading`)
```

``` html
<h1 id="heading"><a class="markdownIt-Anchor" href="#heading">Heading</a></h1>
```

I needed this for my site and I figured it wouldn't hurt to merge this feature in.
