### PR TITLE
Fix a bug which occurs when the heading has no children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ export default function(md, options) {
 
       if (heading.type === "inline") {
         let content
-        if (heading.children && heading.children[0].type === "link_open") {
+        if (heading.children.length > 0 && heading.children[0].type === "link_open") {
           // headings that contain links have to be processed
           // differently since nested links aren't allowed in markdown
           content = heading.children[1].content

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,8 @@ export default function(md, options) {
 
       if (heading.type === "inline") {
         let content
-        if (heading.children.length > 0 && heading.children[0].type === "link_open") {
+        if (heading.children.length > 0 &&
+            heading.children[0].type === "link_open") {
           // headings that contain links have to be processed
           // differently since nested links aren't allowed in markdown
           content = heading.children[1].content


### PR DESCRIPTION
Hi. I hit an error `TypeError: Cannot read property 'type' of undefined` when I write such a markdown below:
```
# hoge

##
```

<img width="270" alt="screen shot 2017-03-19 at 23 50 22" src="https://cloud.githubusercontent.com/assets/11307908/24090605/feddbe70-0cfe-11e7-9b77-8213d3924d62.png">


<img width="515" alt="screen shot 2017-03-19 at 23 33 27" src="https://cloud.githubusercontent.com/assets/11307908/24090588/e13b99d2-0cfe-11e7-9b7a-83ddce1ac69c.png">
