### PR TITLE
Handle null in tocClassName and anchorClassName in order to not include css classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Allows you to enable/disable the toc transformation of `@[toc]`
 
 (default: `"markdownIt-TOC"`)
 
-Option to customize html class of the `<ul>` wrapping the toc
+Option to customize html class of the `<ul>` wrapping the toc. If no class is wanted set to `null`.
 
 #### `tocFirstLevel`
 
@@ -178,7 +178,7 @@ Allows you to prepend/append the anchor link in the headings
 
 (default: `"markdownIt-Anchor"`)
 
-Allows you to customize the anchor link class
+Allows you to customize the anchor link class. If no class is wanted set to `null`.
 
 #### `resetIds`
 

--- a/src/__tests__/anchor.js
+++ b/src/__tests__/anchor.js
@@ -59,4 +59,20 @@ test("markdown-it-toc-and-anchor anchor", (t) => {
     "<span class=\"octicon octicon-link\"></span></a>Heading</h1>\n",
     "should support GitHub style anchor link"
   )
+
+  t.is(
+    mdIt(
+      `@[toc]
+# Heading
+`,
+      {
+        anchorLink: true,
+        anchorClassName: null,
+      }
+    ),
+    `<p></p>
+<h1 id="heading"><a href="#heading">#</a> Heading</h1>
+`,
+    "should handle not include default class in anchors when setting anchorClassName to null"
+  )
 })

--- a/src/__tests__/anchor.js
+++ b/src/__tests__/anchor.js
@@ -73,6 +73,6 @@ test("markdown-it-toc-and-anchor anchor", (t) => {
     `<p></p>
 <h1 id="heading"><a href="#heading">#</a> Heading</h1>
 `,
-    "should handle not include default class in anchors when setting anchorClassName to null"
+    "should handle not including default class in anchors when setting anchorClassName to null"
   )
 })

--- a/src/__tests__/anchor.js
+++ b/src/__tests__/anchor.js
@@ -73,6 +73,7 @@ test("markdown-it-toc-and-anchor anchor", (t) => {
     `<p></p>
 <h1 id="heading"><a href="#heading">#</a> Heading</h1>
 `,
-    "should handle not including default class in anchors when setting anchorClassName to null"
+    "should handle not including default class" + 
+    " in anchors when setting anchorClassName to null"
   )
 })

--- a/src/__tests__/toc.js
+++ b/src/__tests__/toc.js
@@ -100,6 +100,24 @@ and next element in the same inline token`
   t.is(
     mdIt(
       `@[toc]
+# Heading`,
+      {
+        toc: true,
+        tocClassName: null,
+      }
+    ),
+    `<p><ul>
+<li><a href="#heading">Heading</a></li>
+</ul>
+</p>
+<h1 id="heading">Heading</h1>\n`,
+/* eslint-disable max-len */
+  "should handle not including default class in anchors when setting tocClassName to null"
+  )
+
+  t.is(
+    mdIt(
+      `@[toc]
 # 新年快乐`,
       {
         toc: true,

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,10 @@ export default function(md, options) {
     if (typeof tocTokens[0] === "object" &&
         tocTokens[0].type === "bullet_list_open") {
       const attrs = tocTokens[0].attrs = tocTokens[0].attrs || []
-      attrs.push([ "class", options.tocClassName ])
+
+      if (options.tocClassName != null) {
+        attrs.push([ "class", options.tocClassName ])
+      }
     }
 
     tocHtml = markdownItSecondInstance.renderer.render(

--- a/src/index.js
+++ b/src/index.js
@@ -53,12 +53,19 @@ const renderAnchorLinkSymbol = (options) => {
 }
 
 const renderAnchorLink = (anchor, options, tokens, idx) => {
+  const attributes = []
+  
+  if (options.anchorClassName != null) {
+    attributes.push([ "class", options.anchorClassName ])
+  }
+
+  attributes.push([ "href", `#${anchor}` ])
+
   const linkTokens = [
     {
       ...(new Token("link_open", "a", 1)),
       attrs: [
-        [ "class", options.anchorClassName ],
-        [ "href", `#${anchor}` ],
+        ...attributes,
       ],
     },
     ...(renderAnchorLinkSymbol(options)),


### PR DESCRIPTION
I've added new test cases testing the new functionality and updated the documentation. There is another property which can receive a custom css class (`anchorLinkSymbolClassName`) but I don't really understand what it does so I haven't changed that. Let me know if the code could be improved.

This is my first contribution to an open source project so if I've missed anything let me know. Thanks!